### PR TITLE
Add an --all flag to run every automatic option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This program will automatically complete search requests and quizzes on Microsof
 		- `--mobile` is for mobile search
 		- `--pc` is for pc search
 		- `--quiz` is for quiz search  
+		- `-a` or `--all` is short for mobile, pc, and quiz search
 	- Script by will execute mobile, pc, edge, searches, and complete quizzes for all accounts (can change this setting in the .py file)
 	- Script by default will run headlessly (can change this setting in the .py file)  
 	- Run time for one account is under 5 minutes, for 100% daily completion 

--- a/ms_rewards.py
+++ b/ms_rewards.py
@@ -105,12 +105,23 @@ def parse_args():
         default=False,
         help='Activates quiz mode, default is off.')
     arg_parser.add_argument(
+        '-a', '--all',
+        action='store_true',
+        dest='all_mode',
+        default=False,
+        help='Activates all automated modes (equivalent to --mobile --pc --quiz).')
+    arg_parser.add_argument(
         '--log-level',
         default='INFO',
         dest='log_level',
         type=_log_level_string_to_int,
         help=f'Set the logging output level. {_LOG_LEVEL_STRINGS}')
-    return arg_parser.parse_args()
+    parser = arg_parser.parse_args()
+    if parser.all_mode:
+        parser.mobile_mode = True
+        parser.pc_mode = True
+        parser.quiz_mode = True
+    return parser
 
 
 def get_dates(days_to_get=4):


### PR DESCRIPTION
Seems like running --mobile --pc --quiz is a very common use case since it's everything that requires no manual control, here's a little shorthand for it that might be useful. And in the future if any more automatic modes are implemented they could also be triggered by --all