### PR TITLE
adds option to ignore non standard W3C command

### DIFF
--- a/ms_rewards.py
+++ b/ms_rewards.py
@@ -239,6 +239,7 @@ def browser_setup(headless_mode, user_agent):
     options.add_argument(f'user-agent={user_agent}')
     options.add_argument('--no-sandbox')
     options.add_argument('--disable-dev-shm-usage')
+    options.add_experimental_option('w3c', False)
 
     chrome_obj = webdriver.Chrome(path, chrome_options=options)
 


### PR DESCRIPTION
Fixes issue "selenium.common.exceptions.WebDriverException: Message: unknown command: Cannot call non W3C standard command while in W3C mode"