### PR TITLE
Add support for 2FA via Microsoft Authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This program will automatically complete search requests and quizzes on Microsof
 <h2>Features</h2> 
  
 - Completes PC search, Edge search, Mobile search via user agents
-- Retrieves top daily searches via google trends' API
+- Retrieves top daily searches via Google Trends' API
 - Completes polls, all types of quizzes (multiple choice, click and drag and reorder), and explore dailies 
 - Headless mode (Confirmed working on DigitalOcean linux droplet)  
 - Supports unlimited accounts via JSON, in randomized order.  
-- Randomized search speeds   
-- Logs errors and info by default, can log executed commands and search terms via changing log.level to logging.DEBUG
+- Randomized search speeds
+- Logs errors and info by default, can log executed commands and search terms by changing the log level to DEBUG
 - Tested and confirmed working for U.S. and U.K. (more to come!)  
 
 <h2>REQUIREMENTS</h2>
@@ -24,8 +24,7 @@ This program will automatically complete search requests and quizzes on Microsof
 - Python 3.6
 - Requests 2.21.0
 - Selenium 3.14.0
-
-- Chrome Browser 
+- Chrome Browser
 
 <h2>HOW TO USE</h2> 
 
@@ -40,8 +39,13 @@ This program will automatically complete search requests and quizzes on Microsof
 		- `--pc` is for pc search
 		- `--quiz` is for quiz search  
 		- `-a` or `--all` is short for mobile, pc, and quiz search
-	- Script by will execute mobile, pc, edge, searches, and complete quizzes for all accounts (can change this setting in the .py file)
-	- Script by default will run headlessly (can change this setting in the .py file)  
+		- `--authenticator` use Microsoft Authenticator prompts instead of passwords
+    		- **When using Microsoft Authenticator:**
+        		- Headless mode is always disabled
+        		- Respond to the prompt within 90 seconds and Approve the sign in request
+        		- Learn how to use and download the app at [https://go.microsoft.com/fwlink/?linkid=871853](https://go.microsoft.com/fwlink/?linkid=871853)
+	- Script by default will execute mobile, pc, edge, searches, and complete quizzes for all accounts (can change this setting in the .py file)
+	- Script by default will run in interactive mode
 	- Run time for one account is under 5 minutes, for 100% daily completion 
 	- If python environment variable is not set, enter `/path/to/python/executable ms_rewards.py`  
 5. For completing points from email links:

--- a/ms_rewards.py
+++ b/ms_rewards.py
@@ -122,6 +122,12 @@ def parse_args():
         default=False,
         help='Activates all automated modes (equivalent to --mobile --pc --quiz).')
     arg_parser.add_argument(
+        '--authenticator',
+        action='store_true',
+        dest='use_authenticator',
+        default=False,
+        help='Use MS Authenticator instead of a password for ALL accounts. Disables headless mode, default is off.')
+    arg_parser.add_argument(
         '--log-level',
         default='INFO',
         dest='log_level',
@@ -132,6 +138,8 @@ def parse_args():
         _parser.mobile_mode = True
         _parser.pc_mode = True
         _parser.quiz_mode = True
+    if _parser.use_authenticator:
+        _parser.headless_setting = False
     return _parser
 
 
@@ -255,16 +263,24 @@ def log_in(email_address, pass_word):
     time.sleep(0.5)
     send_key_by_name('loginfmt', Keys.RETURN)
     logging.debug(msg='Sent Email Address.')
-    # wait for password form and enter password
-    time.sleep(0.5)
-    wait_until_clickable(By.NAME, 'passwd', 10)
-    send_key_by_name('passwd', pass_word)
-    logging.debug(msg='Sent Password.')
-    # wait for 'sign in' button to be clickable and sign in
-    time.sleep(0.5)
-    send_key_by_name('passwd', Keys.RETURN)
-    time.sleep(0.5)
-    wait_until_visible(By.ID, 'uhfLogo', 10)
+    time.sleep(10)
+
+    if not parser.use_authenticator:
+        # wait for password form and enter password
+        time.sleep(0.5)
+        wait_until_clickable(By.NAME, 'passwd', 10)
+        send_key_by_name('passwd', pass_word)
+        logging.debug(msg='Sent Password.')
+        # wait for 'sign in' button to be clickable and sign in
+        time.sleep(0.5)
+        send_key_by_name('passwd', Keys.RETURN)
+        time.sleep(0.5)
+        # Passwords only require the standard delay
+        wait_until_visible(By.ID, 'uhfLogo', 10)
+    else:
+        # If using mobile 2FA, add a longer delay for sign in approval
+        wait_until_visible(By.ID, 'uhfLogo', 300)
+
     time.sleep(0.5)
 
 


### PR DESCRIPTION
Support the use of [Microsoft Authenticator](https://www.microsoft.com/en-us/account/authenticator) via the `--authenticator` argument. This setting currently affects all configured accounts. 

Fixes #24, and is one workaround for #81.
